### PR TITLE
Add rules to require componentWillLoad on components and require a componentWillLoad decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,5 +83,29 @@ To turn this rule on for your project, add it to the `rules` field in your ESLin
 ```js
 // .eslintrc.js
   rules: {
-    '@manifoldco/stencil/require-render-logger': ['error', { decaratorName: 'renAndStimpyLoveLogs' }],
+    '@manifoldco/stencil/require-render-decorator': ['error', { decaratorName: 'renAndStimpyLoveLogs' }],
+```
+
+### require-componentWillLoad-decorator
+
+This rule requires all Stencil components to decorate their `componentWillLoad` methods with a given decorator. One possible use for this is to set a performance mark at load time for your component.
+
+To turn this rule on for your project, add it to the `rules` field in your ESLint configuration. By default, the decorator name will be `loadMark`, but you can override this in the options array:
+
+```js
+// .eslintrc.js
+  rules: {
+    '@manifoldco/stencil/require-componentWillLoad-decorator': ['error', { decaratorName: 'loadMark' }],
+```
+
+### require-componentWillLoad
+
+This rule requires all Stencil components to declare a componentWillLoad method. This is useful when combined with the above rule to ensure that all components are decorated with the above decorator.
+
+To turn this rule on for your project, add it to the `rules` field in your ESLint configuration.
+
+```js
+// .eslintrc.js
+  rules: {
+    '@manifoldco/stencil/require-componentWillLoad': ['error', {}],
 ```

--- a/index.test.js
+++ b/index.test.js
@@ -163,7 +163,7 @@ export class ManifoldSelect {
   }
 }`;
 
-const componentWithOtherDecorator = `
+let componentWithOtherDecorator = `
 import { h, Component, Prop } from '@stencil/core';
 
 @Component({ tag: 'quux-component' })
@@ -196,6 +196,102 @@ ruleTester.run(
       {
         code: componentMissingLogger,
         errors: [{ messageId: "decoratorMissing" }]
+      }
+    ]
+  }
+);
+
+const componentMissingLoadMark = `
+import { h, Component, Prop } from '@stencil/core';
+
+@Component({ tag: 'quux-component' })
+export class ManifoldSelect {
+  @Prop() answer: number = 42;
+
+  componentWillLoad() {}
+}`;
+
+const componentWithLoadMark = `
+import { h, Component, Prop } from '@stencil/core';
+
+@Component({ tag: 'quux-component' })
+export class ManifoldSelect {
+  @Prop() answer: number = 42;
+
+  @loadMark()
+  componentWillLoad() {}
+}`;
+
+const componentWithOtherComponentWillLoadDecorator = `
+import { h, Component, Prop } from '@stencil/core';
+
+@Component({ tag: 'quux-component' })
+export class ManifoldSelect {
+  @Prop() answer: number = 42;
+
+  @quux()
+  componentWillLoad() {}
+}`;
+
+ruleTester.run(
+  "require-componentWillLoad-decorator",
+  plugin.rules["require-componentWillLoad-decorator"],
+  {
+    valid: [
+      {
+        code: isNotAComponent
+      },
+      {
+        code: componentWithLoadMark
+      },
+      {
+        code: componentWithOtherComponentWillLoadDecorator,
+        options: [{ decoratorName: "quux" }],
+      }
+    ],
+    invalid: [
+      {
+        code: componentMissingLoadMark,
+        errors: [{ messageId: "decoratorMissing" }]
+      }
+    ]
+  }
+);
+
+const componentWithComponentWillLoad = `
+import { h, Component, Prop } from '@stencil/core';
+
+@Component({ tag: 'quux-component' })
+export class ManifoldSelect {
+  @Prop() answer: number = 42;
+
+  componentWillLoad() {}
+}`;
+
+const componentMissingComponentWillLoad = `
+import { h, Component, Prop } from '@stencil/core';
+
+@Component({ tag: 'quux-component' })
+export class ManifoldSelect {
+  @Prop() answer: number = 42;
+}`;
+
+ruleTester.run(
+  "require-componentWillLoad",
+  plugin.rules["require-componentWillLoad"],
+  {
+    valid: [
+      {
+        code: isNotAComponent
+      },
+      {
+        code: componentWithComponentWillLoad
+      }
+    ],
+    invalid: [
+      {
+        code: componentMissingComponentWillLoad,
+        errors: [{ messageId: "componentWillLoadMissing" }]
       }
     ]
   }


### PR DESCRIPTION
Adds two new rules:
- `require-componentWillLoad`: ensures that all components declare a `componentWillLoad` method
- `require-componentWillLoad-decorator`: a shameless copy/paste of existing `require-render-decorator` rule